### PR TITLE
Update cd-workflow.yml

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -60,7 +60,7 @@ jobs:
         name: webpack artifacts
         path: public
     - name: Build container image
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
         username: ${{github.actor}}
         password: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Failed with: Warning: Input 'repository' has been deprecated with message: v2 is now available through docker/build-push-action@v2
Updated docker/build-push-action